### PR TITLE
Phantomjs command line options

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ Shrimp.configure do |config|
   # the timeout for the phantomjs rendering process in ms
   # this needs always to be higher than rendering_time
   # config.rendering_timeout       = 90000
+
+  # the command line options passed to phantomjs
+  # command line options can be found at https://github.com/ariya/phantomjs/wiki/API-Reference
+  # config.phantomjs_command_line_options       = "--ignore-ssl-errors=true --web-security=false"
+ 
 end
 ```
 

--- a/lib/shrimp/configuration.rb
+++ b/lib/shrimp/configuration.rb
@@ -2,7 +2,7 @@ require 'tmpdir'
 module Shrimp
   class Configuration
     attr_accessor :default_options
-    attr_writer :phantomjs
+    attr_writer :phantomjs, :phantomjs_command_line_options
 
     [:format, :margin, :zoom, :orientation, :tmpdir, :rendering_timeout, :rendering_time].each do |m|
       define_method("#{m}=") do |val|
@@ -24,6 +24,10 @@ module Shrimp
 
     def phantomjs
       @phantomjs ||= (defined?(Bundler::GemfileError) ? `bundle exec which phantomjs` : `which phantomjs`).chomp
+    end
+
+    def phantomjs_command_line_options
+      @phantomjs_command_line_options ||= nil
     end
   end
 

--- a/lib/shrimp/middleware.rb
+++ b/lib/shrimp/middleware.rb
@@ -128,7 +128,7 @@ module Shrimp
           <head>
         </head>
           <body onLoad="setTimeout(function(){ window.location.reload()}, #{interval * 1000});">
-          <h2>Prepareing pdf... </h2>
+          <h2>Preparing pdf... </h2>
           </body>
         </ html>
       HTML

--- a/lib/shrimp/phantom.rb
+++ b/lib/shrimp/phantom.rb
@@ -22,7 +22,7 @@ module Shrimp
   end
 
   class Phantom
-    attr_accessor :source, :configuration, :outfile
+    attr_accessor :source, :configuration, :outfile, :phantomjs_command_line_options
     attr_reader :options, :cookies, :result, :error
     SCRIPT_FILE = File.expand_path('../rasterize.js', __FILE__)
 
@@ -55,7 +55,7 @@ module Shrimp
       cookie_file                       = dump_cookies
       format, zoom, margin, orientation = options[:format], options[:zoom], options[:margin], options[:orientation]
       rendering_time, timeout           = options[:rendering_time], options[:rendering_timeout]
-      phantomjs_command_line_options    = options[:phantomjs_command_line_options]
+      phantomjs_command_line_options    = Shrimp.configuration.phantomjs_command_line_options
       @outfile                          ||= "#{options[:tmpdir]}/#{Digest::MD5.hexdigest((Time.now.to_i + rand(9001)).to_s)}.pdf"
 
       [Shrimp.configuration.phantomjs, phantomjs_command_line_options, SCRIPT_FILE, @source.to_s, @outfile, format, zoom, margin, orientation, cookie_file, rendering_time, timeout].join(" ")

--- a/lib/shrimp/phantom.rb
+++ b/lib/shrimp/phantom.rb
@@ -55,9 +55,10 @@ module Shrimp
       cookie_file                       = dump_cookies
       format, zoom, margin, orientation = options[:format], options[:zoom], options[:margin], options[:orientation]
       rendering_time, timeout           = options[:rendering_time], options[:rendering_timeout]
+      phantomjs_command_line_options    = options[:phantomjs_command_line_options]
       @outfile                          ||= "#{options[:tmpdir]}/#{Digest::MD5.hexdigest((Time.now.to_i + rand(9001)).to_s)}.pdf"
 
-      [Shrimp.configuration.phantomjs, SCRIPT_FILE, @source.to_s, @outfile, format, zoom, margin, orientation, cookie_file, rendering_time, timeout].join(" ")
+      [Shrimp.configuration.phantomjs, phantomjs_command_line_options, SCRIPT_FILE, @source.to_s, @outfile, format, zoom, margin, orientation, cookie_file, rendering_time, timeout].join(" ")
     end
 
     # Public: initializes a new Phantom Object


### PR DESCRIPTION
I was having problems creating pdfs on pages with ssl errors.

This adds ability to send command line options to phantomjs found at 
https://github.com/ariya/phantomjs/wiki/API-Reference

Usage: 

`````` ruby
config.phantomjs_command_line_options  = "--ignore-ssl-errors=true --web-security=false"```

``````
