### PR TITLE
Generates PDFs Inline

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ Shrimp.configure do |config|
 
   # a temporary dir used to store tempfiles
   # config.tmpdir           = Dir.tmpdir
+
+  # whether or not exceptions should explicitly be raised
+  # config.fail_silently    = false
+
+  # the maximum time spent rendering a pdf
+  # config.rendering_time   = 30000
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@ Read our [blogpost](http://big-elephants.com/2012-12/pdf-rendering-with-phantomj
 
 Add this line to your application's Gemfile:
 
-    gem 'shrimp', :git => https://github.com/yoccodog/shrimp.git
+    gem 'shrimp'
 
 And then execute:
 
     $ bundle
 
-Or clone it yourself as:
+Or install it yourself as:
 
-    $ git clone install https://github.com/yoccodog/shrimp.git
+    $ gem install shrimp
 
 
 ### pantomjs

--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ Shrimp comes with a middleware that allows users to get a PDF view of any page o
 ### Troubleshooting
 
 *  **Single thread issue:** In development environments it is common to run a
-   single server process. This can cause issues when rendering your pdf
-   requires wkhtmltopdf to hit your server again (for images, js, css).
+   single server process. This can cause issues because rendering your pdf
+   requires phantomjs to hit your server again (for images, js, css).
    This is because the resource requests will get blocked by the initial
    request and the initial request will be waiting on the resource
    requests causing a deadlock.
@@ -119,6 +119,7 @@ Shrimp comes with a middleware that allows users to get a PDF view of any page o
         worker_processes 3
    
    Then to run the app `unicorn_rails -c config/unicorn.conf` (from rails_root)
+  (taken from pdfkit readme: https://github.com/pdfkit/pdfkit)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Shrimp
 [![Build Status](https://travis-ci.org/adeven/shrimp.png?branch=master)](https://travis-ci.org/adeven/shrimp)
-Creates PDFs from URLs using phantomjs
+Creates PDFs from URLs using phantomjs.
 
 Read our [blogpost](http://big-elephants.com/2012-12/pdf-rendering-with-phantomjs/) about how it works.
 
@@ -8,15 +8,15 @@ Read our [blogpost](http://big-elephants.com/2012-12/pdf-rendering-with-phantomj
 
 Add this line to your application's Gemfile:
 
-    gem 'shrimp'
+    gem 'shrimp', :git => https://github.com/yoccodog/shrimp.git
 
 And then execute:
 
     $ bundle
 
-Or install it yourself as:
+Or clone it yourself as:
 
-    $ gem install shrimp
+    $ git clone install https://github.com/yoccodog/shrimp.git
 
 
 ### pantomjs
@@ -42,7 +42,7 @@ Shrimp.configure do |config|
 
   # the default pdf output format
   # e.g. "5in*7.5in", "10cm*20cm", "A4", "Letter"
-  # config.format           = 'A4'
+  # config.format           = 'Letter'
 
   # the default margin
   # config.margin           = '1cm'
@@ -55,14 +55,6 @@ Shrimp.configure do |config|
 
   # a temporary dir used to store tempfiles
   # config.tmpdir           = Dir.tmpdir
-
-  # the default rendering time in ms
-  # increase if you need to render very complex pages
-  # config.rendering_time   = 1000
-
-  # the timeout for the phantomjs rendering process in ms
-  # this needs always to be higher than rendering_time
-  # config.rendering_timeout       = 90000
 end
 ```
 
@@ -106,51 +98,27 @@ Shrimp comes with a middleware that allows users to get a PDF view of any page o
     config.middleware.use Shrimp::Middleware, {}, :except => ['/secret']
 
 
-### Polling
+### Troubleshooting
 
-To avoid deadlocks Shrimp::Middleware renders the pdf in a separate process retuning a 503 Retry-After response Header.
-you can setup the polling interval and the polling offset in seconds.
+*  **Single thread issue:** In development environments it is common to run a
+   single server process. This can cause issues when rendering your pdf
+   requires wkhtmltopdf to hit your server again (for images, js, css).
+   This is because the resource requests will get blocked by the initial
+   request and the initial request will be waiting on the resource
+   requests causing a deadlock.
 
-    config.middleware.use Shrimp::Middleware, :polling_interval => 1, :polling_offset => 5
-
-### Caching
-
-To avoid rendering the page on each request you can setup some the cache ttl in seconds
-
-    config.middleware.use Shrimp::Middleware, :cache_ttl => 3600, :out_path => "my/pdf/store"
-
-
-### Ajax requests
-
-To include some fancy Ajax stuff with jquery
-
-```js
-
- var url = '/my_page.pdf'
- var statusCodes = {
-      200: function() {
-        return window.location.assign(url);
-      },
-      504: function() {
-       console.log("Shit's beeing wired")
-      },
-      503: function(jqXHR, textStatus, errorThrown) {
-        var wait;
-        wait = parseInt(jqXHR.getResponseHeader('Retry-After'));
-        return setTimeout(function() {
-          return $.ajax({
-            url: url,
-            statusCode: statusCodes
-          });
-        }, wait * 1000);
-      }
-  }
-  $.ajax({
-    url: url,
-    statusCode: statusCodes
-  })
-
-```
+   This is usually not an issue in a production environment. To get
+   around this issue you may want to run a server with multiple workers
+   like Passenger or try to embed your resources within your HTML to
+   avoid extra HTTP requests.
+   
+   Example solution (rails / bundler), add unicorn to the development 
+   group in your Gemfile `gem 'unicorn'` then run `bundle`. Next, add a 
+   file `config/unicorn.conf` with
+   
+        worker_processes 3
+   
+   Then to run the app `unicorn_rails -c config/unicorn.conf` (from rails_root)
 
 ## Contributing
 

--- a/lib/shrimp/configuration.rb
+++ b/lib/shrimp/configuration.rb
@@ -4,7 +4,7 @@ module Shrimp
     attr_accessor :default_options
     attr_writer :phantomjs
 
-    [:format, :margin, :zoom, :orientation, :tmpdir, :rendering_timeout, :rendering_time].each do |m|
+    [:format, :margin, :zoom, :orientation, :tmpdir].each do |m|
       define_method("#{m}=") do |val|
         @default_options[m]=val
       end
@@ -12,13 +12,11 @@ module Shrimp
 
     def initialize
       @default_options = {
-          :format            => 'A4',
+          :format            => 'Letter',
           :margin            => '1cm',
           :zoom              => 1,
           :orientation       => 'portrait',
-          :tmpdir            => Dir.tmpdir,
-          :rendering_timeout => 90000,
-          :rendering_time    => 1000
+          :tmpdir            => Dir.tmpdir
       }
     end
 

--- a/lib/shrimp/configuration.rb
+++ b/lib/shrimp/configuration.rb
@@ -1,42 +1,41 @@
 require 'tmpdir'
+
+# Configure Phantomjs someplace sensible,
+# like config/initializers/phantomjs.rb
+#
+# @example
+#   Shrimp.configure do |config|
+#     config.phantomjs = '/usr/local/bin/phantomjs'
+#     config.format = 'Letter'
+#   end
 module Shrimp
   class Configuration
-    attr_accessor :default_options
-    attr_writer :phantomjs
+    attr_accessor :options
 
-    [:format, :margin, :zoom, :orientation, :tmpdir].each do |m|
+    [:format, :margin, :zoom, :orientation, :tmpdir, :phantomjs, 
+     :rendering_time, :fail_silently].each do |m|
       define_method("#{m}=") do |val|
-        @default_options[m]=val
+        @options[m]=val
       end
     end
 
     def initialize
-      @default_options = {
+      @options = {
           :format            => 'Letter',
           :margin            => '1cm',
           :zoom              => 1,
           :orientation       => 'portrait',
-          :tmpdir            => Dir.tmpdir
+          :tmpdir            => Dir.tmpdir,
+          :phantomjs         => Phantom.default_executable,
+          :rendering_time    => 30000,
+          :fail_silently     => false
       }
-    end
-
-    def phantomjs
-      @phantomjs ||= (defined?(Bundler::GemfileError) ? `bundle exec which phantomjs` : `which phantomjs`).chomp
     end
   end
 
   class << self
     attr_accessor :configuration
   end
-
-  # Configure Phantomjs someplace sensible,
-  # like config/initializers/phantomjs.rb
-  #
-  # @example
-  #   Shrimp.configure do |config|
-  #     config.phantomjs = '/usr/local/bin/phantomjs'
-  #     config.format = 'Letter'
-  #   end
 
   def self.configuration
     @configuration ||= Configuration.new

--- a/lib/shrimp/middleware.rb
+++ b/lib/shrimp/middleware.rb
@@ -9,7 +9,8 @@ module Shrimp
     def call(env)
       @request = Rack::Request.new(env)
       if render_as_pdf? #&& headers['Content-Type'] =~ /text\/html|application\/xhtml\+xml/
-        Phantom.new(@request.url.sub(%r{\.pdf}, ''), @options, 
+        Phantom.new(Shrimp.configuration.options[:phantomjs], 
+                    @request.url.sub(%r{\.pdf}, ''), @options, 
                     @request.cookies).to_pdf(render_to) 
         file = File.open(render_to, "rb")
         body = file.read
@@ -29,7 +30,7 @@ module Shrimp
 
     def render_to
       file_name = Digest::MD5.hexdigest(@request.path) + ".pdf"
-      file_path = Shrimp.configuration.default_options[:tmpdir]
+      file_path = Shrimp.configuration.options[:tmpdir]
       "#{file_path}/#{file_name}"
     end
 

--- a/lib/shrimp/middleware.rb
+++ b/lib/shrimp/middleware.rb
@@ -9,8 +9,8 @@ module Shrimp
     def call(env)
       @request = Rack::Request.new(env)
       if render_as_pdf? #&& headers['Content-Type'] =~ /text\/html|application\/xhtml\+xml/
-        Phantom.new(@options[:phantomjs], @request.url.sub(%r{\.pdf}, ''), 
-                    @options, @request.cookies).to_pdf(render_to) 
+        Phantom.new(@request.url.sub(%r{\.pdf}, ''), @options, 
+                    @request.cookies).to_pdf(render_to) 
         file = File.open(render_to, "rb")
         body = file.read
         file.close

--- a/lib/shrimp/middleware.rb
+++ b/lib/shrimp/middleware.rb
@@ -4,47 +4,22 @@ module Shrimp
       @app                        = app
       @options                    = options
       @conditions                 = conditions
-      @options[:polling_interval] ||= 1
-      @options[:polling_offset]   ||= 1
-      @options[:cache_ttl]        ||= 1
-      @options[:request_timeout]  ||= @options[:polling_interval] * 10
     end
 
     def call(env)
       @request = Rack::Request.new(env)
       if render_as_pdf? #&& headers['Content-Type'] =~ /text\/html|application\/xhtml\+xml/
-        if already_rendered? && (up_to_date?(@options[:cache_ttl]) || @options[:cache_ttl] == 0)
-          if File.size(render_to) == 0
-            File.delete(render_to)
-            remove_rendering_flag
-            return error_response
-          end
-          return ready_response if env['HTTP_X_REQUESTED_WITH']
-          file = File.open(render_to, "rb")
-          body = file.read
-          file.close
-          File.delete(render_to) if @options[:cache_ttl] == 0
-          remove_rendering_flag
-          response                  = [body]
-          headers                   = { }
-          headers["Content-Length"] = (body.respond_to?(:bytesize) ? body.bytesize : body.size).to_s
-          headers["Content-Type"]   = "application/pdf"
-          [200, headers, response]
-        else
-          if rendering_in_progress?
-            if rendering_timed_out?
-              remove_rendering_flag
-              error_response
-            else
-              reload_response(@options[:polling_interval])
-            end
-          else
-            File.delete(render_to) if already_rendered?
-            set_rendering_flag
-            fire_phantom
-            reload_response(@options[:polling_offset])
-          end
-        end
+        Phantom.new(@options[:phantomjs], @request.url.sub(%r{\.pdf}, ''), 
+                    @options, @request.cookies).to_pdf(render_to) 
+        file = File.open(render_to, "rb")
+        body = file.read
+        file.close
+        File.delete(render_to)
+        response                  = [body]
+        headers                   = { }
+        headers["Content-Length"] = (body.respond_to?(:bytesize) ? body.bytesize : body.size).to_s
+        headers["Content-Type"]   = "application/pdf"
+        [200, headers, response]
       else
         @app.call(env)
       end
@@ -52,47 +27,14 @@ module Shrimp
 
     private
 
-    # Private: start phantom rendering in a separate process
-    def fire_phantom
-      Process::detach fork { Phantom.new(@request.url.sub(%r{\.pdf$}, ''), @options, @request.cookies).to_pdf(render_to) }
-    end
-
     def render_to
       file_name = Digest::MD5.hexdigest(@request.path) + ".pdf"
-      file_path = @options[:out_path]
+      file_path = Shrimp.configuration.default_options[:tmpdir]
       "#{file_path}/#{file_name}"
     end
 
-    def already_rendered?
-      File.exists?(render_to)
-    end
-
-    def up_to_date?(ttl = 30)
-      (Time.now - File.new(render_to).mtime) <= ttl
-    end
-
-
-    def remove_rendering_flag
-      @request.session["phantom-rendering"] ||={ }
-      @request.session["phantom-rendering"].delete(render_to)
-    end
-
-    def set_rendering_flag
-      @request.session["phantom-rendering"]            ||={ }
-      @request.session["phantom-rendering"][render_to] = Time.now
-    end
-
-    def rendering_timed_out?
-      Time.now - @request.session["phantom-rendering"][render_to] > @options[:request_timeout]
-    end
-
-    def rendering_in_progress?
-      @request.session["phantom-rendering"]||={ }
-      @request.session["phantom-rendering"][render_to]
-    end
-
     def render_as_pdf?
-      request_path_is_pdf = !!@request.path.match(%r{\.pdf$})
+      request_path_is_pdf = !!@request.path.match(%r{\.pdf})
 
       if request_path_is_pdf && @conditions[:only]
         rules = [@conditions[:only]].flatten
@@ -122,54 +64,5 @@ module Shrimp
       (accepts || '').split(',').unshift(type).compact.join(',')
     end
 
-    def reload_response(interval=1)
-      body = <<-HTML.gsub(/[ \n]+/, ' ').strip
-          <html>
-          <head>
-        </head>
-          <body onLoad="setTimeout(function(){ window.location.reload()}, #{interval * 1000});">
-          <h2>Preparing pdf... </h2>
-          </body>
-        </ html>
-      HTML
-      headers                   = { }
-      headers["Content-Length"] = body.size.to_s
-      headers["Content-Type"]   = "text/html"
-      headers["Retry-After"]    = interval.to_s
-
-      [503, headers, [body]]
-    end
-
-    def ready_response
-      body = <<-HTML.gsub(/[ \n]+/, ' ').strip
-        <html>
-        <head>
-        </head>
-        <body>
-        <a href="#{@request.path}">PDF ready here</a>
-        </body>
-      </ html>
-      HTML
-      headers                   = { }
-      headers["Content-Length"] = body.size.to_s
-      headers["Content-Type"]   = "text/html"
-      [200, headers, [body]]
-    end
-
-    def error_response
-      body = <<-HTML.gsub(/[ \n]+/, ' ').strip
-        <html>
-        <head>
-        </head>
-        <body>
-        <h2>Sorry request timed out... </h2>
-        </body>
-      </ html>
-      HTML
-      headers                   = { }
-      headers["Content-Length"] = body.size.to_s
-      headers["Content-Type"]   = "text/html"
-      [504, headers, [body]]
-    end
   end
 end

--- a/lib/shrimp/phantom.rb
+++ b/lib/shrimp/phantom.rb
@@ -1,5 +1,7 @@
 require 'uri'
 require 'json'
+require 'digest'
+
 module Shrimp
   class NoExecutableError < StandardError
     def initialize(phantom_location=nil)
@@ -26,23 +28,32 @@ module Shrimp
     attr_reader :options, :cookies, :result, :error
     SCRIPT_FILE = File.expand_path('../rasterize.js', __FILE__)
     
+    def self.default_executable
+      (defined?(Bundler::GemfileError) ?  
+       `bundle exec which phantomjs` : 
+       `which phantomjs`).chomp
+    end
+
     # Public: initializes a new Phantom Object
     #
     # url_or_file - The url of the html document to render
     # options     - a hash with options for rendering
-    #   * format  - the paper format for the output eg: "5in*7.5in", "10cm*20cm", "A4", "Letter"
+    #   * format  - the paper format for the output eg: "5in*7.5in", 
+    #               "10cm*20cm", "A4", "Letter"
     #   * zoom    - the viewport zoom factor
     #   * margin  - the margins for the pdf
     # cookies     - hash with cookies to use for rendering
-    # outfile     - optional path for the output file a Tempfile will be created if not given
+    # outfile     - optional path for the output file. a Tempfile will be 
+    #               created if not given
     #
     # Returns self
-    def initialize(url_or_file, options = { }, cookies={ }, outfile = nil)
+    def initialize(executable, url_or_file, options = {}, cookies={}, 
+                   outfile = nil)
       @source  = Source.new(url_or_file)
-      @options = Shrimp.configuration.default_options.merge(options)
+      @options = Shrimp.configuration.options.merge(options)
       @cookies = cookies
-      @outfile = File.expand_path(outfile) if outfile
-      @executable = Shrimp.configuration.phantomjs
+      @outfile = outfile ? File.expand_path(outfile) : tmpfile
+      @executable = executable || Phantom.default_executable
       raise NoExecutableError.new(@executable) unless File.exists?(@executable)
     end
 
@@ -55,29 +66,16 @@ module Shrimp
       unless $?.exitstatus == 0
         @error  = @result
         @result = nil
-      end
-      @result
-    end
-
-    def run!
-      @error  = nil
-      @result = `#{cmd}`
-      unless $?.exitstatus == 0
-        @error  = @result
-        @result = nil
-        raise RenderingError.new(@error)
+        raise RenderingError.new(@error) unless options[:fail_silently]
       end
       @result
     end
 
     # Public: Returns the phantom rasterize command
     def cmd
-      cookie_file                       = dump_cookies
-      format, zoom, margin, orientation = options[:format], options[:zoom], options[:margin], options[:orientation]
-      rendering_time, timeout           = options[:rendering_time], options[:rendering_timeout]
-      @outfile                          ||= "#{options[:tmpdir]}/#{Digest::MD5.hexdigest((Time.now.to_i + rand(9001)).to_s)}.pdf"
-
-      [@executable, SCRIPT_FILE, @source.to_s, @outfile, format, zoom, margin, orientation, cookie_file, rendering_time, timeout].join(" ")
+      [@executable, SCRIPT_FILE, @source.to_s, @outfile, @options[:format], 
+       @options[:zoom], @options[:margin], @options[:orientation], 
+       dump_cookies, @options[:rendering_time]].join(" ")
     end
 
     # Public: renders to pdf
@@ -107,26 +105,20 @@ module Shrimp
       File.open(self.to_pdf(path)).read
     end
 
-    def to_pdf!(path=nil)
-      @outfile = File.expand_path(path) if path
-      self.run!
-      @outfile
-    end
-
-    def to_file!(path=nil)
-      self.to_pdf!(path)
-      File.new(@outfile)
-    end
-
-    def to_string!(path=nil)
-      File.open(self.to_pdf!(path)).read
-    end
-
     private
+    def tmpfile 
+      "#{options[:tmpdir]}/#{Digest::MD5.hexdigest((
+                             Time.now.to_i + rand(9001)).to_s)}.pdf"
+    end
+
     def dump_cookies
       host = @source.url? ? URI::parse(@source.to_s).host : "/"
-      json = @cookies.inject([]) { |a, (k, v)| a.push({ :name => k, :value => v, :domain => host }); a }.to_json
-      File.open("#{options[:tmpdir]}/#{rand}.cookies", 'w') { |f| f.puts json; f }.path
+      json = @cookies.inject([]) { |a, (k, v)| 
+               a.push({ :name => k, :value => v, :domain => host }); a 
+             }.to_json
+      File.open("#{options[:tmpdir]}/#{rand}.cookies", 'w') { |f| 
+        f.puts json; f 
+      }.path
     end
   end
 end

--- a/lib/shrimp/phantom.rb
+++ b/lib/shrimp/phantom.rb
@@ -2,29 +2,49 @@ require 'uri'
 require 'json'
 module Shrimp
   class NoExecutableError < StandardError
-    def initialize
-      msg = "No phantomjs executable found at #{Shrimp.configuration.phantomjs}\n"
+    def initialize(phantom_location=nil)
+      msg = "No phantomjs executable found at #{phantom_location}\n"
       msg << ">> Please install phantomjs - http://phantomjs.org/download.html"
       super(msg)
     end
   end
 
   class ImproperSourceError < StandardError
-    def initialize(msg = nil)
+    def initialize(msg=nil)
       super("Improper Source: #{msg}")
     end
   end
 
   class RenderingError < StandardError
-    def initialize(msg = nil)
+    def initialize(msg=nil)
       super("Rendering Error: #{msg}")
     end
   end
 
   class Phantom
-    attr_accessor :source, :configuration, :outfile
+    attr_accessor :source, :configuration, :outfile, :executable
     attr_reader :options, :cookies, :result, :error
     SCRIPT_FILE = File.expand_path('../rasterize.js', __FILE__)
+    
+    # Public: initializes a new Phantom Object
+    #
+    # url_or_file - The url of the html document to render
+    # options     - a hash with options for rendering
+    #   * format  - the paper format for the output eg: "5in*7.5in", "10cm*20cm", "A4", "Letter"
+    #   * zoom    - the viewport zoom factor
+    #   * margin  - the margins for the pdf
+    # cookies     - hash with cookies to use for rendering
+    # outfile     - optional path for the output file a Tempfile will be created if not given
+    #
+    # Returns self
+    def initialize(executable, url_or_file, options = { }, cookies={ }, outfile = nil)
+      @source  = Source.new(url_or_file)
+      @options = Shrimp.configuration.default_options.merge(options)
+      @cookies = cookies
+      @outfile = File.expand_path(outfile) if outfile
+      @executable = executable
+      raise NoExecutableError.new(@executable) unless File.exists?(@executable)
+    end
 
     # Public: Runs the phantomjs binary
     #
@@ -57,26 +77,7 @@ module Shrimp
       rendering_time, timeout           = options[:rendering_time], options[:rendering_timeout]
       @outfile                          ||= "#{options[:tmpdir]}/#{Digest::MD5.hexdigest((Time.now.to_i + rand(9001)).to_s)}.pdf"
 
-      [Shrimp.configuration.phantomjs, SCRIPT_FILE, @source.to_s, @outfile, format, zoom, margin, orientation, cookie_file, rendering_time, timeout].join(" ")
-    end
-
-    # Public: initializes a new Phantom Object
-    #
-    # url_or_file - The url of the html document to render
-    # options     - a hash with options for rendering
-    #   * format  - the paper format for the output eg: "5in*7.5in", "10cm*20cm", "A4", "Letter"
-    #   * zoom    - the viewport zoom factor
-    #   * margin  - the margins for the pdf
-    # cookies     - hash with cookies to use for rendering
-    # outfile     - optional path for the output file a Tempfile will be created if not given
-    #
-    # Returns self
-    def initialize(url_or_file, options = { }, cookies={ }, outfile = nil)
-      @source  = Source.new(url_or_file)
-      @options = Shrimp.configuration.default_options.merge(options)
-      @cookies = cookies
-      @outfile = File.expand_path(outfile) if outfile
-      raise NoExecutableError.new unless File.exists?(Shrimp.configuration.phantomjs)
+      [@executable, SCRIPT_FILE, @source.to_s, @outfile, format, zoom, margin, orientation, cookie_file, rendering_time, timeout].join(" ")
     end
 
     # Public: renders to pdf

--- a/lib/shrimp/phantom.rb
+++ b/lib/shrimp/phantom.rb
@@ -37,12 +37,12 @@ module Shrimp
     # outfile     - optional path for the output file a Tempfile will be created if not given
     #
     # Returns self
-    def initialize(executable, url_or_file, options = { }, cookies={ }, outfile = nil)
+    def initialize(url_or_file, options = { }, cookies={ }, outfile = nil)
       @source  = Source.new(url_or_file)
       @options = Shrimp.configuration.default_options.merge(options)
       @cookies = cookies
       @outfile = File.expand_path(outfile) if outfile
-      @executable = executable
+      @executable = Shrimp.configuration.phantomjs
       raise NoExecutableError.new(@executable) unless File.exists?(@executable)
     end
 

--- a/lib/shrimp/rasterize.js
+++ b/lib/shrimp/rasterize.js
@@ -10,7 +10,7 @@ var page = require('webpage').create(),
   address, output, size, statusCode;
 
 window.setTimeout(function () {
-  console.log("Shit's being weird no result within: " + time_out + "ms");
+  console.log("Dayum... Shit's being weird no result within: " + time_out + "ms");
   phantom.exit(1);
 }, time_out);
 

--- a/lib/shrimp/version.rb
+++ b/lib/shrimp/version.rb
@@ -1,3 +1,3 @@
 module Shrimp
-  VERSION = "0.0.2"
+  VERSION = "0.1.0"
 end

--- a/shrimp.gemspec
+++ b/shrimp.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency(%q<rake>, [">=0.9.2"])
   gem.add_development_dependency(%q<rspec>, [">= 2.2.0"])
   gem.add_development_dependency(%q<rack-test>, [">= 0.5.6"])
+  gem.add_development_dependency(%q<pry>)
 end

--- a/spec/shrimp/middleware_spec.rb
+++ b/spec/shrimp/middleware_spec.rb
@@ -9,7 +9,6 @@ def options
     format: 'Letter', 
     margin: '1cm', 
     tmpdir: Dir.tmpdir, 
-    phantomjs: '/home/justin/Downloads/phantomjs-1.9.1-linux-x86_64/bin/phantomjs'
   }
 end
 
@@ -22,6 +21,9 @@ def mock_app(options = { }, conditions = { })
   @middleware = Shrimp::Middleware.new(main_app, options, conditions)
   @app        = Rack::Session::Cookie.new(@middleware, key: 'rack.session', secret: '53cr3t')
   #@middleware.should_receive(:fire_phantom).any_number_of_times
+  Shrimp.configure do |config|
+    config.phantomjs = '/home/justin/Downloads/phantomjs-1.9.1-linux-x86_64/bin/phantomjs'
+  end
 end
 
 

--- a/spec/shrimp/middleware_spec.rb
+++ b/spec/shrimp/middleware_spec.rb
@@ -20,9 +20,8 @@ def mock_app(options = { }, conditions = { })
 
   @middleware = Shrimp::Middleware.new(main_app, options, conditions)
   @app        = Rack::Session::Cookie.new(@middleware, key: 'rack.session', secret: '53cr3t')
-  #@middleware.should_receive(:fire_phantom).any_number_of_times
   Shrimp.configure do |config|
-    config.phantomjs = 'configure a phantomjs location'
+    config.phantomjs = '/home/justin/Downloads/phantomjs-1.9.1-linux-x86_64/bin/phantomjs'
   end
 end
 
@@ -31,6 +30,12 @@ describe Shrimp::Middleware do
   before { mock_app(options) }
 
   context "matching pdf" do
+    before(:each) do
+      Shrimp.configure do |config|
+        config.fail_silently = true
+      end
+    end
+
     it "should render as pdf" do
       get '/test.pdf'
       @middleware.send(:'render_as_pdf?').should be true

--- a/spec/shrimp/middleware_spec.rb
+++ b/spec/shrimp/middleware_spec.rb
@@ -22,7 +22,7 @@ def mock_app(options = { }, conditions = { })
   @app        = Rack::Session::Cookie.new(@middleware, key: 'rack.session', secret: '53cr3t')
   #@middleware.should_receive(:fire_phantom).any_number_of_times
   Shrimp.configure do |config|
-    config.phantomjs = '/home/justin/Downloads/phantomjs-1.9.1-linux-x86_64/bin/phantomjs'
+    config.phantomjs = 'configure a phantomjs location'
   end
 end
 

--- a/spec/shrimp/middleware_spec.rb
+++ b/spec/shrimp/middleware_spec.rb
@@ -5,20 +5,23 @@ def app;
 end
 
 def options
-  { :margin          => "1cm", :out_path => Dir.tmpdir,
-    :polling_offset  => 10, :polling_interval => 1, :cache_ttl => 3600,
-    :request_timeout => 1 }
+  { 
+    format: 'Letter', 
+    margin: '1cm', 
+    tmpdir: Dir.tmpdir, 
+    phantomjs: '/home/justin/Downloads/phantomjs-1.9.1-linux-x86_64/bin/phantomjs'
+  }
 end
 
 def mock_app(options = { }, conditions = { })
   main_app = lambda { |env|
-    headers = { 'Content-Type' => "text/html" }
+    headers = { 'Content-Type' => 'text/html' }
     [200, headers, ['Hello world!']]
   }
 
   @middleware = Shrimp::Middleware.new(main_app, options, conditions)
-  @app        = Rack::Session::Cookie.new(@middleware, :key => 'rack.session')
-  @middleware.should_receive(:fire_phantom).any_number_of_times
+  @app        = Rack::Session::Cookie.new(@middleware, key: 'rack.session', secret: '53cr3t')
+  #@middleware.should_receive(:fire_phantom).any_number_of_times
 end
 
 
@@ -30,55 +33,16 @@ describe Shrimp::Middleware do
       get '/test.pdf'
       @middleware.send(:'render_as_pdf?').should be true
     end
-    it "should return 503 the first time" do
+
+    it "should set render to to tmpdir" do
       get '/test.pdf'
-      last_response.status.should eq 503
-      last_response.header["Retry-After"].should eq "10"
+      @middleware.send(:render_to).should match (Regexp.new("^#{options[:tmpdir]}"))
     end
-
-    it "should return 503 the with polling interval the second time" do
-      get '/test.pdf'
-      get '/test.pdf'
-      last_response.status.should eq 503
-      last_response.header["Retry-After"].should eq "1"
-    end
-
-    it "should set render to to outpath" do
-      get '/test.pdf'
-      @middleware.send(:render_to).should match (Regexp.new("^#{options[:out_path]}"))
-    end
-
-    it "should return 504 on timeout" do
-      get '/test.pdf'
-      sleep 1
-      get '/test.pdf'
-      last_response.status.should eq 504
-    end
-
-    it "should retry rendering after timeout" do
-      get '/test.pdf'
-      sleep 1
-      get '/test.pdf'
-      get '/test.pdf'
-      last_response.status.should eq 503
-    end
-
-    it "should return a pdf with 200 after rendering" do
-      mock_file = mock(File, :read => "Hello World", :close => true, :mtime => Time.now)
-      File.should_receive(:'exists?').and_return true
-      File.should_receive(:'size').and_return 1000
-      File.should_receive(:'open').and_return mock_file
-      File.should_receive(:'new').and_return mock_file
-      get '/test.pdf'
-      last_response.status.should eq 200
-      last_response.body.should eq "Hello World"
-    end
-
-
   end
+
   context "not matching pdf" do
     it "should skip pdf rendering" do
-      get 'http://www.example.org/test'
+      get '/test'
       last_response.body.should include "Hello world!"
       @middleware.send(:'render_as_pdf?').should be false
     end

--- a/spec/shrimp/phantom_spec.rb
+++ b/spec/shrimp/phantom_spec.rb
@@ -20,7 +20,7 @@ describe Shrimp::Phantom do
       config.format = 'Letter'
       config.margin = '1cm'
       config.tmpdir = Dir.tmpdir
-      config.phantomjs = '/home/justin/Downloads/phantomjs-1.9.1-linux-x86_64/bin/phantomjs'
+      config.phantomjs = 'configure a phantomjs location'
     end
   end
 

--- a/spec/shrimp/phantom_spec.rb
+++ b/spec/shrimp/phantom_spec.rb
@@ -25,8 +25,7 @@ describe Shrimp::Phantom do
   end
 
   it "should initialize attributes" do
-    phantom = Shrimp::Phantom.new(Shrimp.configuration.phantomjs, 
-                                  "file://#{testfile}", { :margin => "2cm" }, 
+    phantom = Shrimp::Phantom.new("file://#{testfile}", { :margin => "2cm" }, 
                                   { }, "#{Dir.tmpdir}/test.pdf")
     phantom.source.to_s.should eq "file://#{testfile}"
     phantom.options[:margin].should eq "2cm"
@@ -39,20 +38,17 @@ describe Shrimp::Phantom do
   end
 
   it "should accept a local file url" do
-    phantom = Shrimp::Phantom.new(Shrimp.configuration.phantomjs, 
-                                  "file://#{testfile}")
+    phantom = Shrimp::Phantom.new("file://#{testfile}")
     phantom.source.should be_url
   end
 
   it "should accept a URL as source" do
-    phantom = Shrimp::Phantom.new(Shrimp.configuration.phantomjs, 
-                                  "http://google.com")
+    phantom = Shrimp::Phantom.new("http://google.com")
     phantom.source.should be_url
   end
 
   it "should parse options into a cmd line" do
-    phantom = Shrimp::Phantom.new(Shrimp.configuration.phantomjs, 
-                                  "file://#{testfile}", 
+    phantom = Shrimp::Phantom.new("file://#{testfile}", 
                                   { format: 'Letter', margin: "2cm" }, 
                                   { }, "#{Dir.tmpdir}/test.pdf")
     phantom.cmd.should include "test.pdf Letter 1 2cm portrait"
@@ -62,8 +58,7 @@ describe Shrimp::Phantom do
 
   context "rendering to a file" do
     before(:all) do
-      phantom = Shrimp::Phantom.new(Shrimp.configuration.phantomjs, 
-                                    "file://#{testfile}", { :margin => "2cm" }, 
+      phantom = Shrimp::Phantom.new("file://#{testfile}", { :margin => "2cm" }, 
                                     { }, "#{Dir.tmpdir}/test.pdf")
       @result = phantom.to_file
     end
@@ -79,8 +74,7 @@ describe Shrimp::Phantom do
 
   context "rendering to a pdf" do
     before(:all) do
-      @phantom = Shrimp::Phantom.new(Shrimp.configuration.phantomjs, 
-                                     "file://#{testfile}", { :margin => "2cm" }, 
+      @phantom = Shrimp::Phantom.new("file://#{testfile}", { :margin => "2cm" }, 
                                      { })
       @result  = @phantom.to_pdf("#{Dir.tmpdir}/test.pdf")
     end
@@ -97,8 +91,7 @@ describe Shrimp::Phantom do
 
   context "rendering to a String" do
     before(:all) do
-      phantom = Shrimp::Phantom.new(Shrimp.configuration.phantomjs, 
-                                    "file://#{testfile}", { :margin => "2cm" }, 
+      phantom = Shrimp::Phantom.new("file://#{testfile}", { :margin => "2cm" }, 
                                     { })
       @result = phantom.to_string("#{Dir.tmpdir}/test.pdf")
     end
@@ -114,15 +107,13 @@ describe Shrimp::Phantom do
 
   context "Error" do
     it "should return result nil" do
-      phantom = Shrimp::Phantom.new(Shrimp.configuration.phantomjs, 
-                                    "file://foo/bar")
+      phantom = Shrimp::Phantom.new("file://foo/bar")
       @result = phantom.run
       @result.should be_nil
     end
 
     it "should be unable to load the address" do
-      phantom = Shrimp::Phantom.new(Shrimp.configuration.phantomjs, 
-                                    "file:///foo/bar")
+      phantom = Shrimp::Phantom.new("file:///foo/bar")
       phantom.run
       phantom.error.should include "Unable to load the address"
     end
@@ -131,14 +122,12 @@ describe Shrimp::Phantom do
   context "Error Bang!" do
 
     it "should be unable to load the address" do
-      phantom = Shrimp::Phantom.new(Shrimp.configuration.phantomjs, 
-                                    "file:///foo/bar")
+      phantom = Shrimp::Phantom.new("file:///foo/bar")
       expect { phantom.run! }.to raise_error Shrimp::RenderingError
     end
 
     it "should be unable to copy file" do
-      phantom = Shrimp::Phantom.new(Shrimp.configuration.phantomjs, 
-                                    "file://#{testfile}")
+      phantom = Shrimp::Phantom.new("file://#{testfile}")
       expect { phantom.to_pdf!("/foo/bar/") }.to raise_error Shrimp::RenderingError
     end
   end

--- a/spec/shrimp/phantom_spec.rb
+++ b/spec/shrimp/phantom_spec.rb
@@ -14,19 +14,20 @@ def testfile
   File.expand_path('../test_file.html', __FILE__)
 end
 
-Shrimp.configure do |config|
-  config.rendering_time = 1000
-end
-
 describe Shrimp::Phantom do
   before do
     Shrimp.configure do |config|
-      config.rendering_time = 1000
+      config.format = 'Letter'
+      config.margin = '1cm'
+      config.tmpdir = Dir.tmpdir
+      config.phantomjs = '/home/justin/Downloads/phantomjs-1.9.1-linux-x86_64/bin/phantomjs'
     end
   end
 
   it "should initialize attributes" do
-    phantom = Shrimp::Phantom.new("file://#{testfile}", { :margin => "2cm" }, { }, "#{Dir.tmpdir}/test.pdf")
+    phantom = Shrimp::Phantom.new(Shrimp.configuration.phantomjs, 
+                                  "file://#{testfile}", { :margin => "2cm" }, 
+                                  { }, "#{Dir.tmpdir}/test.pdf")
     phantom.source.to_s.should eq "file://#{testfile}"
     phantom.options[:margin].should eq "2cm"
     phantom.outfile.should eq "#{Dir.tmpdir}/test.pdf"
@@ -38,25 +39,32 @@ describe Shrimp::Phantom do
   end
 
   it "should accept a local file url" do
-    phantom = Shrimp::Phantom.new("file://#{testfile}")
+    phantom = Shrimp::Phantom.new(Shrimp.configuration.phantomjs, 
+                                  "file://#{testfile}")
     phantom.source.should be_url
   end
 
   it "should accept a URL as source" do
-    phantom = Shrimp::Phantom.new("http://google.com")
+    phantom = Shrimp::Phantom.new(Shrimp.configuration.phantomjs, 
+                                  "http://google.com")
     phantom.source.should be_url
   end
 
   it "should parse options into a cmd line" do
-    phantom = Shrimp::Phantom.new("file://#{testfile}", { :margin => "2cm" }, { }, "#{Dir.tmpdir}/test.pdf")
-    phantom.cmd.should include "test.pdf A4 1 2cm portrait"
+    phantom = Shrimp::Phantom.new(Shrimp.configuration.phantomjs, 
+                                  "file://#{testfile}", 
+                                  { format: 'Letter', margin: "2cm" }, 
+                                  { }, "#{Dir.tmpdir}/test.pdf")
+    phantom.cmd.should include "test.pdf Letter 1 2cm portrait"
     phantom.cmd.should include "file://#{testfile}"
     phantom.cmd.should include "lib/shrimp/rasterize.js"
   end
 
   context "rendering to a file" do
     before(:all) do
-      phantom = Shrimp::Phantom.new("file://#{testfile}", { :margin => "2cm" }, { }, "#{Dir.tmpdir}/test.pdf")
+      phantom = Shrimp::Phantom.new(Shrimp.configuration.phantomjs, 
+                                    "file://#{testfile}", { :margin => "2cm" }, 
+                                    { }, "#{Dir.tmpdir}/test.pdf")
       @result = phantom.to_file
     end
 
@@ -71,7 +79,9 @@ describe Shrimp::Phantom do
 
   context "rendering to a pdf" do
     before(:all) do
-      @phantom = Shrimp::Phantom.new("file://#{testfile}", { :margin => "2cm" }, { })
+      @phantom = Shrimp::Phantom.new(Shrimp.configuration.phantomjs, 
+                                     "file://#{testfile}", { :margin => "2cm" }, 
+                                     { })
       @result  = @phantom.to_pdf("#{Dir.tmpdir}/test.pdf")
     end
 
@@ -87,7 +97,9 @@ describe Shrimp::Phantom do
 
   context "rendering to a String" do
     before(:all) do
-      phantom = Shrimp::Phantom.new("file://#{testfile}", { :margin => "2cm" }, { })
+      phantom = Shrimp::Phantom.new(Shrimp.configuration.phantomjs, 
+                                    "file://#{testfile}", { :margin => "2cm" }, 
+                                    { })
       @result = phantom.to_string("#{Dir.tmpdir}/test.pdf")
     end
 
@@ -102,33 +114,31 @@ describe Shrimp::Phantom do
 
   context "Error" do
     it "should return result nil" do
-      phantom = Shrimp::Phantom.new("file://foo/bar")
+      phantom = Shrimp::Phantom.new(Shrimp.configuration.phantomjs, 
+                                    "file://foo/bar")
       @result = phantom.run
       @result.should be_nil
     end
 
     it "should be unable to load the address" do
-      phantom = Shrimp::Phantom.new("file:///foo/bar")
+      phantom = Shrimp::Phantom.new(Shrimp.configuration.phantomjs, 
+                                    "file:///foo/bar")
       phantom.run
       phantom.error.should include "Unable to load the address"
-    end
-
-    it "should be unable to copy file" do
-      phantom = Shrimp::Phantom.new("file://#{testfile}")
-      phantom.to_pdf("/foo/bar/")
-      phantom.error.should include "Unable to copy file "
     end
   end
 
   context "Error Bang!" do
 
     it "should be unable to load the address" do
-      phantom = Shrimp::Phantom.new("file:///foo/bar")
+      phantom = Shrimp::Phantom.new(Shrimp.configuration.phantomjs, 
+                                    "file:///foo/bar")
       expect { phantom.run! }.to raise_error Shrimp::RenderingError
     end
 
     it "should be unable to copy file" do
-      phantom = Shrimp::Phantom.new("file://#{testfile}")
+      phantom = Shrimp::Phantom.new(Shrimp.configuration.phantomjs, 
+                                    "file://#{testfile}")
       expect { phantom.to_pdf!("/foo/bar/") }.to raise_error Shrimp::RenderingError
     end
   end

--- a/spec/shrimp/phantom_spec.rb
+++ b/spec/shrimp/phantom_spec.rb
@@ -14,121 +14,118 @@ def testfile
   File.expand_path('../test_file.html', __FILE__)
 end
 
-describe Shrimp::Phantom do
-  before do
+
+describe Shrimp do
+  before(:all) do 
     Shrimp.configure do |config|
-      config.format = 'Letter'
-      config.margin = '1cm'
-      config.tmpdir = Dir.tmpdir
-      config.phantomjs = 'configure a phantomjs location'
+      config.phantomjs = '/home/justin/Downloads/phantomjs-1.9.1-linux-x86_64/bin/phantomjs'
     end
+    @executable = Shrimp.configuration.options[:phantomjs]
   end
 
-  it "should initialize attributes" do
-    phantom = Shrimp::Phantom.new("file://#{testfile}", { :margin => "2cm" }, 
-                                  { }, "#{Dir.tmpdir}/test.pdf")
-    phantom.source.to_s.should eq "file://#{testfile}"
-    phantom.options[:margin].should eq "2cm"
-    phantom.outfile.should eq "#{Dir.tmpdir}/test.pdf"
-  end
+  describe Shrimp::Phantom do
+    before do
+      Shrimp.configure do |config|
+        config.format = 'Letter'
+        config.margin = '1cm'
+        config.tmpdir = Dir.tmpdir
+        config.fail_silently = false
+      end
+    end
 
-  it "should render a pdf file" do
-    #phantom = Shrimp::Phantom.new("file://#{@path}")
-    #phantom.to_pdf("#{Dir.tmpdir}/test.pdf").first should eq "#{Dir.tmpdir}/test.pdf"
-  end
+    it "should initialize attributes" do
+      phantom = Shrimp::Phantom.new(@executable, "file://#{testfile}", 
+                                    { :margin => "2cm" }, { }, 
+                                    "#{Dir.tmpdir}/test.pdf")
+      phantom.source.to_s.should eq "file://#{testfile}"
+      phantom.options[:margin].should eq "2cm"
+      phantom.outfile.should eq "#{Dir.tmpdir}/test.pdf"
+    end
 
-  it "should accept a local file url" do
-    phantom = Shrimp::Phantom.new("file://#{testfile}")
-    phantom.source.should be_url
-  end
+    it "should accept a local file url" do
+      phantom = Shrimp::Phantom.new(@executable,"file://#{testfile}")
+      phantom.source.should be_url
+    end
 
-  it "should accept a URL as source" do
-    phantom = Shrimp::Phantom.new("http://google.com")
-    phantom.source.should be_url
-  end
+    it "should accept a URL as source" do
+      phantom = Shrimp::Phantom.new(@executable,"http://google.com")
+      phantom.source.should be_url
+    end
 
-  it "should parse options into a cmd line" do
-    phantom = Shrimp::Phantom.new("file://#{testfile}", 
-                                  { format: 'Letter', margin: "2cm" }, 
-                                  { }, "#{Dir.tmpdir}/test.pdf")
-    phantom.cmd.should include "test.pdf Letter 1 2cm portrait"
-    phantom.cmd.should include "file://#{testfile}"
-    phantom.cmd.should include "lib/shrimp/rasterize.js"
-  end
-
-  context "rendering to a file" do
-    before(:all) do
-      phantom = Shrimp::Phantom.new("file://#{testfile}", { :margin => "2cm" }, 
+    it "should parse options into a cmd line" do
+      phantom = Shrimp::Phantom.new(@executable, "file://#{testfile}", 
+                                    { format: 'Letter', margin: "2cm" }, 
                                     { }, "#{Dir.tmpdir}/test.pdf")
-      @result = phantom.to_file
+      phantom.cmd.should include "test.pdf Letter 1 2cm portrait"
+      phantom.cmd.should include "file://#{testfile}"
+      phantom.cmd.should include "lib/shrimp/rasterize.js"
     end
 
-    it "should return a File" do
-      @result.should be_a File
+    context "rendering to a file" do
+      before(:all) do
+        phantom = Shrimp::Phantom.new(@executable, "file://#{testfile}", 
+                                      { :margin => "2cm" }, { }, 
+                                      "#{Dir.tmpdir}/test.pdf")
+        @result = phantom.to_file
+      end
+
+      it "should return a File" do
+        @result.should be_a File
+      end
+
+      it "should be a valid pdf" do
+        valid_pdf(@result)
+      end
     end
 
-    it "should be a valid pdf" do
-      valid_pdf(@result)
-    end
-  end
+    context "rendering to a pdf" do
+      before(:all) do
+        @phantom = Shrimp::Phantom.new(@executable, "file://#{testfile}", 
+                                       { :margin => "2cm" }, { })
+        @result  = @phantom.to_pdf("#{Dir.tmpdir}/test.pdf")
+      end
 
-  context "rendering to a pdf" do
-    before(:all) do
-      @phantom = Shrimp::Phantom.new("file://#{testfile}", { :margin => "2cm" }, 
-                                     { })
-      @result  = @phantom.to_pdf("#{Dir.tmpdir}/test.pdf")
-    end
+      it "should return a path to pdf" do
+        @result.should be_a String
+        @result.should eq "#{Dir.tmpdir}/test.pdf"
+      end
 
-    it "should return a path to pdf" do
-      @result.should be_a String
-      @result.should eq "#{Dir.tmpdir}/test.pdf"
-    end
-
-    it "should be a valid pdf" do
-      valid_pdf(@result)
-    end
-  end
-
-  context "rendering to a String" do
-    before(:all) do
-      phantom = Shrimp::Phantom.new("file://#{testfile}", { :margin => "2cm" }, 
-                                    { })
-      @result = phantom.to_string("#{Dir.tmpdir}/test.pdf")
+      it "should be a valid pdf" do
+        valid_pdf(@result)
+      end
     end
 
-    it "should return the File IO String" do
-      @result.should be_a String
+    context "rendering to a String" do
+      before(:all) do
+        phantom = Shrimp::Phantom.new(@executable, "file://#{testfile}", 
+                                      { :margin => "2cm" }, { })
+        @result = phantom.to_string("#{Dir.tmpdir}/test.pdf")
+      end
+
+      it "should return the File IO String" do
+        @result.should be_a String
+      end
+
+      it "should be a valid pdf" do
+        valid_pdf(@result)
+      end
     end
 
-    it "should be a valid pdf" do
-      valid_pdf(@result)
-    end
-  end
-
-  context "Error" do
-    it "should return result nil" do
-      phantom = Shrimp::Phantom.new("file://foo/bar")
-      @result = phantom.run
-      @result.should be_nil
+    context "failing loudly" do
+      it "should raise a RenderingError" do
+        phantom = Shrimp::Phantom.new(@executable, "file://foo/bar")
+        expect { phantom.run }.to raise_error(Shrimp::RenderingError)
+      end
     end
 
-    it "should be unable to load the address" do
-      phantom = Shrimp::Phantom.new("file:///foo/bar")
-      phantom.run
-      phantom.error.should include "Unable to load the address"
-    end
-  end
-
-  context "Error Bang!" do
-
-    it "should be unable to load the address" do
-      phantom = Shrimp::Phantom.new("file:///foo/bar")
-      expect { phantom.run! }.to raise_error Shrimp::RenderingError
-    end
-
-    it "should be unable to copy file" do
-      phantom = Shrimp::Phantom.new("file://#{testfile}")
-      expect { phantom.to_pdf!("/foo/bar/") }.to raise_error Shrimp::RenderingError
+    context "failing silently" do
+      it "should return nil" do
+        Shrimp.configure do |config|
+          config.fail_silently = true
+        end
+        phantom = Shrimp::Phantom.new(@executable, "file:///foo/bar")
+        phantom.run.should eq(nil)
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require 'rack/test'
 require 'shrimp'
+require 'pry'
 
 RSpec.configure do |config|
   include Rack::Test::Methods


### PR DESCRIPTION
This branch changes the underlying functionality of shrimp so that pdf generation is performed inline rather than in a forked process. This causes shrimp to operate more like pdfkit (which it can be a drop-in replacement for with these changes).

It also removes some duplicate code in the Phantom class by allowing exceptions to be silenced with a flag. 
