### PR TITLE
Add Command Line Configuration Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,22 @@ Shrimp.configure do |config|
   # the timeout for the phantomjs rendering process in ms
   # this needs always to be higher than rendering_time
   # config.rendering_timeout       = 90000
+
+  # the path to a json configuration file for command-line options
+  # config.command_config_file = "#{Rails.root.join('config', 'shrimp', 'config.json')}"
 end
+```
+
+### Command Configuration
+
+```
+{
+    "diskCache": false,
+    "ignoreSslErrors": false,
+    "loadImages": true,
+    "outputEncoding": "utf8",
+    "webSecurity": true
+}
 ```
 
 ## Middleware

--- a/lib/shrimp/config.json
+++ b/lib/shrimp/config.json
@@ -1,0 +1,7 @@
+{
+    "diskCache": false,
+    "ignoreSslErrors": false,
+    "loadImages": true,
+    "outputEncoding": "utf8",
+    "webSecurity": true
+}

--- a/lib/shrimp/configuration.rb
+++ b/lib/shrimp/configuration.rb
@@ -4,7 +4,7 @@ module Shrimp
     attr_accessor :default_options
     attr_writer :phantomjs
 
-    [:format, :margin, :zoom, :orientation, :tmpdir, :rendering_timeout, :rendering_time].each do |m|
+    [:format, :margin, :zoom, :orientation, :tmpdir, :rendering_timeout, :rendering_time, :command_config_file].each do |m|
       define_method("#{m}=") do |val|
         @default_options[m]=val
       end
@@ -12,13 +12,14 @@ module Shrimp
 
     def initialize
       @default_options = {
-          :format            => 'A4',
-          :margin            => '1cm',
-          :zoom              => 1,
-          :orientation       => 'portrait',
-          :tmpdir            => Dir.tmpdir,
-          :rendering_timeout => 90000,
-          :rendering_time    => 1000
+          :format               => 'A4',
+          :margin               => '1cm',
+          :zoom                 => 1,
+          :orientation          => 'portrait',
+          :tmpdir               => Dir.tmpdir,
+          :rendering_timeout    => 90000,
+          :rendering_time       => 1000,
+          :command_config_file  => File.expand_path('../config.json', __FILE__)
       }
     end
 

--- a/lib/shrimp/phantom.rb
+++ b/lib/shrimp/phantom.rb
@@ -56,19 +56,20 @@ module Shrimp
       format, zoom, margin, orientation = options[:format], options[:zoom], options[:margin], options[:orientation]
       rendering_time, timeout           = options[:rendering_time], options[:rendering_timeout]
       @outfile                          ||= "#{options[:tmpdir]}/#{Digest::MD5.hexdigest((Time.now.to_i + rand(9001)).to_s)}.pdf"
-
-      [Shrimp.configuration.phantomjs, SCRIPT_FILE, @source.to_s, @outfile, format, zoom, margin, orientation, cookie_file, rendering_time, timeout].join(" ")
+      command_config_file               = "--config=#{options[:command_config_file]}"
+      [Shrimp.configuration.phantomjs, command_config_file, SCRIPT_FILE, @source.to_s, @outfile, format, zoom, margin, orientation, cookie_file, rendering_time, timeout].join(" ")
     end
 
     # Public: initializes a new Phantom Object
     #
-    # url_or_file - The url of the html document to render
-    # options     - a hash with options for rendering
-    #   * format  - the paper format for the output eg: "5in*7.5in", "10cm*20cm", "A4", "Letter"
-    #   * zoom    - the viewport zoom factor
-    #   * margin  - the margins for the pdf
-    # cookies     - hash with cookies to use for rendering
-    # outfile     - optional path for the output file a Tempfile will be created if not given
+    # url_or_file             - The url of the html document to render
+    # options                 - a hash with options for rendering
+    #   * format              - the paper format for the output eg: "5in*7.5in", "10cm*20cm", "A4", "Letter"
+    #   * zoom                - the viewport zoom factor
+    #   * margin              - the margins for the pdf
+    #   * command_config_file - the path to a json configuration file for command-line options
+    # cookies                 - hash with cookies to use for rendering
+    # outfile                 - optional path for the output file a Tempfile will be created if not given
     #
     # Returns self
     def initialize(url_or_file, options = { }, cookies={ }, outfile = nil)


### PR DESCRIPTION
This will allow shrimp to read from a config.json file using
phantomjs's --config option to set command line options.  The added
config.json are default values.
