### PR TITLE
added options for viewport width and height config

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ Shrimp.configure do |config|
   # increase if you need to render very complex pages
   # config.rendering_time   = 1000
 
+  # change the viewport size.  If you rendering pages that have 
+  # flexible page width and height then you may need to set this
+  # to enforce a specific size
+  # config.viewport_width = 600 
+  # config.viewport_height = 600
+
   # the timeout for the phantomjs rendering process in ms
   # this needs always to be higher than rendering_time
   # config.rendering_timeout       = 90000

--- a/lib/shrimp/configuration.rb
+++ b/lib/shrimp/configuration.rb
@@ -4,7 +4,7 @@ module Shrimp
     attr_accessor :default_options
     attr_writer :phantomjs
 
-    [:format, :margin, :zoom, :orientation, :tmpdir, :rendering_timeout, :rendering_time, :command_config_file].each do |m|
+    [:format, :margin, :zoom, :orientation, :tmpdir, :rendering_timeout, :rendering_time, :command_config_file, :viewport_height, :viewport_height].each do |m|
       define_method("#{m}=") do |val|
         @default_options[m]=val
       end
@@ -19,7 +19,9 @@ module Shrimp
           :tmpdir               => Dir.tmpdir,
           :rendering_timeout    => 90000,
           :rendering_time       => 1000,
-          :command_config_file  => File.expand_path('../config.json', __FILE__)
+          :command_config_file  => File.expand_path('../config.json', __FILE__),
+          :viewport_width       => 600,
+          :viewport_height      => 600
       }
     end
 

--- a/lib/shrimp/configuration.rb
+++ b/lib/shrimp/configuration.rb
@@ -4,7 +4,7 @@ module Shrimp
     attr_accessor :default_options
     attr_writer :phantomjs
 
-    [:format, :margin, :zoom, :orientation, :tmpdir, :rendering_timeout, :rendering_time, :command_config_file, :viewport_height, :viewport_height].each do |m|
+    [:format, :margin, :zoom, :orientation, :tmpdir, :rendering_timeout, :rendering_time, :command_config_file, :viewport_width, :viewport_height].each do |m|
       define_method("#{m}=") do |val|
         @default_options[m]=val
       end

--- a/lib/shrimp/phantom.rb
+++ b/lib/shrimp/phantom.rb
@@ -55,9 +55,10 @@ module Shrimp
       cookie_file                       = dump_cookies
       format, zoom, margin, orientation = options[:format], options[:zoom], options[:margin], options[:orientation]
       rendering_time, timeout           = options[:rendering_time], options[:rendering_timeout]
+      viewport_width, viewport_height   = options[:viewport_width], options[:viewport_height]
       @outfile                          ||= "#{options[:tmpdir]}/#{Digest::MD5.hexdigest((Time.now.to_i + rand(9001)).to_s)}.pdf"
       command_config_file               = "--config=#{options[:command_config_file]}"
-      [Shrimp.configuration.phantomjs, command_config_file, SCRIPT_FILE, @source.to_s, @outfile, format, zoom, margin, orientation, cookie_file, rendering_time, timeout].join(" ")
+      [Shrimp.configuration.phantomjs, command_config_file, SCRIPT_FILE, @source.to_s, @outfile, format, zoom, margin, orientation, cookie_file, rendering_time, timeout, viewport_width, viewport_height ].join(" ")
     end
 
     # Public: initializes a new Phantom Object

--- a/lib/shrimp/rasterize.js
+++ b/lib/shrimp/rasterize.js
@@ -6,6 +6,8 @@ var page = require('webpage').create(),
   cookie_file = system.args[7] ,
   render_time = system.args[8] || 10000 ,
   time_out = system.args[9] || 90000 ,
+  viewport_width = system.args[10] || 600,
+  viewport_height= system.args[11] || 600,
   cookies = {},
   address, output, size, statusCode;
 
@@ -24,14 +26,14 @@ try {
 phantom.cookiesEnabled = true;
 phantom.cookies = cookies;
 
-if (system.args.length < 3 || system.args.length > 10) {
-  console.log('Usage: rasterize.js URL filename [paperwidth*paperheight|paperformat] [zoom] [margin] [orientation] [cookie_file] [render_time] [time_out]');
+if (system.args.length < 3 || system.args.length > 12) {
+  console.log('Usage: rasterize.js URL filename [paperwidth*paperheight|paperformat] [zoom] [margin] [orientation] [cookie_file] [render_time] [time_out] [viewport_width] [viewport_height]');
   console.log('  paper (pdf output) examples: "5in*7.5in", "10cm*20cm", "A4", "Letter"');
   phantom.exit(1);
 } else {
   address = system.args[1];
   output = system.args[2];
-  page.viewportSize = { width:600, height:600 };
+  page.viewportSize = { width: viewport_width, height: viewport_height };
   if (system.args.length > 3 && system.args[2].substr(-4) === ".pdf") {
     size = system.args[3].split('*');
     page.paperSize = size.length === 2 ? { width:size[0], height:size[1], margin:'0px' }


### PR DESCRIPTION
Thanks for the innovative solution to pdf printing, saved me tons of time.  I was running into issues related to the viewport size where my pdf's were not printing quite correctly..  I made a small change to enable them to be configurable vs hard coded in the rasterize.js file.  If this works for you please approve the merge and i'll change my Gemfile back to your repo.
