### PR TITLE
Wrapping URL in quotes to account for special char

### DIFF
--- a/lib/shrimp/phantom.rb
+++ b/lib/shrimp/phantom.rb
@@ -58,7 +58,7 @@ module Shrimp
       viewport_width, viewport_height   = options[:viewport_width], options[:viewport_height]
       @outfile                          ||= "#{options[:tmpdir]}/#{Digest::MD5.hexdigest((Time.now.to_i + rand(9001)).to_s)}.pdf"
       command_config_file               = "--config=#{options[:command_config_file]}"
-      [Shrimp.configuration.phantomjs, command_config_file, SCRIPT_FILE, @source.to_s, @outfile, format, zoom, margin, orientation, cookie_file, rendering_time, timeout, viewport_width, viewport_height ].join(" ")
+      [Shrimp.configuration.phantomjs, command_config_file, SCRIPT_FILE, '"'+@source.to_s+'"', @outfile, format, zoom, margin, orientation, cookie_file, rendering_time, timeout, viewport_width, viewport_height ].join(" ")
     end
 
     # Public: initializes a new Phantom Object


### PR DESCRIPTION
Special characters like & etc. can break shell commands. This prevents it.
