### PR TITLE
allow phantomjs to use any encryption protocol

### DIFF
--- a/lib/shrimp/config.json
+++ b/lib/shrimp/config.json
@@ -1,6 +1,7 @@
 {
     "diskCache": false,
     "ignoreSslErrors": false,
+    "sslProtocol": "any",
     "loadImages": true,
     "outputEncoding": "utf8",
     "webSecurity": true


### PR DESCRIPTION
PhantomJS [defaults to SSLv3](http://phantomjs.org/api/command-line.html) which is vulnerable to the [POODLE attack](https://www.us-cert.gov/ncas/alerts/TA14-290A).

With SSLv3 being disabled on most servers (ours!), rendering PDF will fail with `Shrimp::RenderingError: Rendering Error: SSL handshake failed`

This allows our invocation of PhantomJS to use any available SSL protocol (TLSv1.x).
