### PR TITLE
Allow custom margins (differing values per side)

### DIFF
--- a/lib/shrimp/phantom.rb
+++ b/lib/shrimp/phantom.rb
@@ -55,7 +55,7 @@ module Shrimp
     # Public: Returns the phantom rasterize command
     def cmd
       cookie_file                       = dump_cookies
-      format, zoom, margin, orientation = options[:format], options[:zoom], options[:margin], options[:orientation]
+      format, zoom, margin, orientation = options[:format], options[:zoom], "'#{options[:margin].to_json}'", options[:orientation]
       rendering_time, timeout           = options[:rendering_time], options[:rendering_timeout]
       viewport_width, viewport_height   = options[:viewport_width], options[:viewport_height]
       max_redirect_count                = options[:max_redirect_count]

--- a/lib/shrimp/rasterize.js
+++ b/lib/shrimp/rasterize.js
@@ -126,7 +126,7 @@ if (system.args.length < 3 || system.args.length > 13) {
   if (system.args.length > 3 && system.args[2].substr(-4) === ".pdf") {
     size = system.args[3].split('*');
     page_options.paperSize = size.length === 2 ? { width:size[0], height:size[1], margin:'0px' }
-      : { format:system.args[3], orientation:orientation, margin:margin };
+      : { format:system.args[3], orientation:orientation, margin: JSON.parse(margin) };
   }
   if (system.args.length > 4) {
     page_options.zoomFactor = system.args[4];

--- a/spec/shrimp/phantom_spec.rb
+++ b/spec/shrimp/phantom_spec.rb
@@ -42,6 +42,17 @@ describe Shrimp::Phantom do
     phantom.outfile.should eq "#{Dir.tmpdir}/test.pdf"
   end
 
+  it "should accept margin provided as a hash of sides" do
+    margin = {
+      top: '4.6mm',
+      right: '4mm',
+      left: '3cm',
+      # bottom: '0cm', # default
+    }
+    phantom = Shrimp::Phantom.new("file://#{testfile}", { :margin => margin }, { }, "#{Dir.tmpdir}/test.pdf")
+    phantom.options[:margin].should eq margin
+  end
+
   it "should render a pdf file" do
     #phantom = Shrimp::Phantom.new("file://#{@path}")
     #phantom.to_pdf("#{Dir.tmpdir}/test.pdf").first should eq "#{Dir.tmpdir}/test.pdf"
@@ -59,7 +70,7 @@ describe Shrimp::Phantom do
 
   it "should parse options into a cmd line" do
     phantom = Shrimp::Phantom.new("file://#{testfile}", { :margin => "2cm", :max_redirect_count => 10 }, { }, "#{Dir.tmpdir}/test.pdf")
-    phantom.cmd.should include "test.pdf A4 1 2cm portrait"
+    phantom.cmd.should include "test.pdf A4 1 '\"2cm\"' portrait"
     phantom.cmd.should include "file://#{testfile}"
     phantom.cmd.should include "lib/shrimp/rasterize.js"
     phantom.cmd.should end_with " 10"


### PR DESCRIPTION
Pass the margin hash through to the JS by JSON-ifying it. This makes the argument list to the phantomjs command a little uglier, but I think it's a good way to keep the code simple.

Includes corresponding spec, and updates the command argument list one.
