### PR TITLE
Add support for render pdf with header and/or footer

### DIFF
--- a/lib/shrimp/configuration.rb
+++ b/lib/shrimp/configuration.rb
@@ -5,7 +5,17 @@ module Shrimp
     attr_accessor :default_options
     attr_writer :phantomjs
 
-    [:format, :margin, :zoom, :orientation, :tmpdir, :rendering_timeout, :rendering_time, :command_config_file, :viewport_width, :viewport_height, :max_redirect_count].each do |m|
+    [:format,
+     :margin,
+     :zoom,
+     :orientation,
+     :tmpdir,
+     :rendering_timeout,
+     :rendering_time,
+     :command_config_file,
+     :viewport_width,
+     :viewport_height,
+     :max_redirect_count].each do |m|
       define_method("#{m}=") do |val|
         @default_options[m]=val
       end
@@ -23,7 +33,11 @@ module Shrimp
           :command_config_file  => File.expand_path('../config.json', __FILE__),
           :viewport_width       => 600,
           :viewport_height      => 600,
-          :max_redirect_count   => 0
+          :max_redirect_count   => 0,
+          :header_content       => nil,
+          :footer_content       => nil,
+          :header_size          => '0cm',
+          :footer_size          => '0cm'
       }
     end
 

--- a/lib/shrimp/phantom.rb
+++ b/lib/shrimp/phantom.rb
@@ -163,14 +163,18 @@ module Shrimp
       return nil unless options[:header_content]
 
       a = options[:header_content]
-      a.kind_of?(File) ? a.path : File.open("#{options[:tmpdir]}/#{rand}.header", 'w') { |f| f.puts a; f }.path
+      c = a.kind_of?(File) ? a.read : a
+
+      File.open("#{options[:tmpdir]}/#{rand}.header", 'w') { |f| f.puts c; f }.path
     end
 
     def handle_footer
       return nil unless options[:footer_content]
 
       a = options[:footer_content]
-      a.kind_of?(File) ? a.path : File.open("#{options[:tmpdir]}/#{rand}.footer", 'w') { |f| f.puts a; f }.path
+      c = a.kind_of?(File) ? a.read : a
+
+      File.open("#{options[:tmpdir]}/#{rand}.footer", 'w') { |f| f.puts c; f }.path
     end
   end
 end

--- a/lib/shrimp/phantom.rb
+++ b/lib/shrimp/phantom.rb
@@ -61,6 +61,11 @@ module Shrimp
       max_redirect_count                = options[:max_redirect_count]
       @outfile                          ||= "#{options[:tmpdir]}/#{Digest::MD5.hexdigest((Time.now.to_i + rand(9001)).to_s)}.pdf"
       command_config_file               = "--config=#{options[:command_config_file]}"
+
+      footer_file = handle_footer || Dir.tmpdir + "/#{rand}"
+      header_file = handle_header || Dir.tmpdir + "/#{rand}"
+      footer_size, header_size = options[:footer_size], options[:header_size]
+
       [
         Shrimp.configuration.phantomjs,
         command_config_file,
@@ -76,7 +81,11 @@ module Shrimp
         timeout,
         viewport_width,
         viewport_height,
-        max_redirect_count
+        max_redirect_count,
+        footer_file,
+        footer_size,
+        header_file,
+        header_size
       ].join(" ")
     end
 
@@ -148,6 +157,20 @@ module Shrimp
       host = @source.url? ? URI::parse(@source.to_s).host : "/"
       json = @cookies.inject([]) { |a, (k, v)| a.push({ :name => k, :value => v, :domain => host }); a }.to_json
       File.open("#{options[:tmpdir]}/#{rand}.cookies", 'w') { |f| f.puts json; f }.path
+    end
+
+    def handle_header
+      return nil unless options[:header_content]
+
+      a = options[:header_content]
+      a.kind_of?(File) ? a.path : File.open("#{options[:tmpdir]}/#{rand}.header", 'w') { |f| f.puts a; f }.path
+    end
+
+    def handle_footer
+      return nil unless options[:footer_content]
+
+      a = options[:footer_content]
+      a.kind_of?(File) ? a.path : File.open("#{options[:tmpdir]}/#{rand}.footer", 'w') { |f| f.puts a; f }.path
     end
   end
 end

--- a/lib/shrimp/rasterize.js
+++ b/lib/shrimp/rasterize.js
@@ -1,16 +1,20 @@
 var
-  webpage = require('webpage'),
-  fs      = require('fs'),
-  system  = require('system'),
-  margin          = system.args[5] || '0cm',
-  orientation     = system.args[6] || 'portrait',
+  webpage         = require('webpage'),
+  fs              = require('fs'),
+  system          = require('system'),
+  margin          = system.args[5]   || '0cm',
+  orientation     = system.args[6]   || 'portrait',
   cookie_file     = system.args[7],
-  render_time     = system.args[8] || 10000 ,
-  time_out        = system.args[9] || 90000 ,
-  viewport_width  = system.args[10] || 600,
-  viewport_height = system.args[11] || 600,
-  redirects_num   = system.args[12] || 0,
-  cookies = {},
+  render_time     = system.args[8]   || 10000,
+  time_out        = system.args[9]   || 90000,
+  viewport_width  = system.args[10]  || 600,
+  viewport_height = system.args[11]  || 600,
+  redirects_num   = system.args[12]  || 0,
+  footer_file     = system.args[13],
+  footer_size     = system.args[14]  || '0cm',
+  header_file     = system.args[15],
+  header_size     = system.args[16]  || '0cm',
+  cookies         = {},
   address, output, size;
 
 function error(msg) {
@@ -31,6 +35,7 @@ window.setTimeout(function () {
 
 function renderUrl(url, output, options) {
   options = options || {};
+
 
   var statusCode,
       page = webpage.create();
@@ -110,9 +115,10 @@ if (cookie_file) {
   phantom.cookies = cookies;
 }
 
-if (system.args.length < 3 || system.args.length > 13) {
+if (system.args.length < 3 || system.args.length > 17) {
   print_usage() && phantom.exit(2);
 } else {
+
   address = system.args[1];
   output  = system.args[2];
 
@@ -130,6 +136,45 @@ if (system.args.length < 3 || system.args.length > 13) {
   }
   if (system.args.length > 4) {
     page_options.zoomFactor = system.args[4];
+  }
+
+
+  if (header_file) {
+
+    try {
+      header = fs.open(header_file, "r");
+      header_content = header.read();
+      fs.remove(header_file);
+
+      page_options.paperSize.header = {
+        height: header_size,
+        contents: phantom.callback(function(pageNum, numPages){
+          return header_content.replace('{{total_pages}}', numPages).replace('{{current_page}}', pageNum);
+        })
+      };
+
+    } catch (e) {
+      console.log(e);
+    }
+  }
+
+  if (footer_file) {
+
+    try {
+      footer = fs.open(footer_file, "r");
+      footer_content = footer.read();
+      fs.remove(footer_file);
+
+      page_options.paperSize.footer = {
+        height: footer_size,
+        contents: phantom.callback(function(pageNum, numPages){
+          return footer_content.replace('{{total_pages}}', numPages).replace('{{current_page}}', pageNum);
+        })
+      };
+
+    } catch (e) {
+      console.log(e);
+    }
   }
 
   renderUrl(address, output, page_options);

--- a/spec/shrimp/phantom_spec.rb
+++ b/spec/shrimp/phantom_spec.rb
@@ -62,7 +62,7 @@ describe Shrimp::Phantom do
     phantom.cmd.should include "test.pdf A4 1 2cm portrait"
     phantom.cmd.should include "file://#{testfile}"
     phantom.cmd.should include "lib/shrimp/rasterize.js"
-    phantom.cmd.should end_with " 10"
+    phantom.cmd.should end_with "cm"
   end
 
   it "should properly escape arguments" do


### PR DESCRIPTION
Call with :

``` ruby
require 'shrimp'
url     = 'http://www.google.com'
options = { 
  :margin => "1cm",
  :header_content => 'header, page: {{current_page}}/{{total_pages}}',
  :header_size => '1cm',
  :footer_content => 'footer, <b>page: {{current_page}}/{{total_pages}}</b>',
  :footer_size => '1cm'
}
Shrimp::Phantom.new(url, options).to_pdf("~/output.pdf")
```

`header_content` or `footer_content` value can be a file : 

``` ruby
options = { 
  :header_content => File.open('header_file', 'r'),
  :footer_content => File.open('footer_file', 'r')
}
```
